### PR TITLE
Fix Multi-Class Classifiers, Add Marginal SHAP and custom maskers, Quality of Life

### DIFF
--- a/leverageshap/estimators/leverage_shap.py
+++ b/leverageshap/estimators/leverage_shap.py
@@ -1,40 +1,115 @@
+from abc import ABC, abstractmethod
+from typing import Callable
+
 import numpy as np
-from .sampling import CoalitionSampler
 from scipy.special import comb as binom
 
+from .sampling import CoalitionSampler
 
-class Game:
-    def __init__(self, model, baseline, explicand):
+
+class Game(ABC):
+    def __init__(self, model, explicand):
         self.model = model
-        self.baseline = baseline
         self.explicand = explicand
-    
+
+    @abstractmethod
+    def value(self, S):
+        # S is a m by n binary matrix
+        raise NotImplementedError
+
+    @abstractmethod
+    def edge_cases(self):
+        raise NotImplementedError
+
+
+class BaselineGame(Game):
+    def __init__(self, model, baseline, explicand):
+        super().__init__(model, explicand)
+        self.baseline = baseline
+
     def value(self, S):
         # S is a m by n binary matrix
         inputs = self.baseline * (1 - S) + self.explicand * S
         return self.model.predict(inputs)
-    
+
     def edge_cases(self):
         v0 = self.model.predict(self.baseline)
         v1 = self.model.predict(self.explicand)
         return v0, v1
+
+
+class MarginalGame(Game):
+    def __init__(self, model, background_data, explicand):
+        super().__init__(model, explicand)
+        self.background_data = background_data
+
+    def value(self, S):
+        N, *n = self.background_data.shape
+        m = S.shape[0]
+
+        data = np.expand_dims(self.background_data, axis=0)  # 1 x N x n
+        S = np.expand_dims(S, axis=1)  # m x 1 x n
+        inputs = data * (1 - S) + self.explicand * S
+        inputs = inputs.reshape(-1, *n)  # (m * N) x n
+        values = self.model.predict(inputs).reshape(m, N, -1)
+        return np.mean(values, axis=1)
+
+    def edge_cases(self):
+        v0 = np.mean(self.model.predict(self.background_data), axis=0)
+        v1 = self.model.predict(self.explicand)
+        return v0, v1
+
+
+class CustomMaskerGame(Game):
+    """Game that uses a custom masker to compute the value of the game.
+
+    Args:
+        model: The model to evaluate.
+        masker: A function that takes a m x n binary matrix and an explicand n-vector
+            It returns a m x N x n matrix.
+            Unline in the `shap` library, the masker needs to accept batched masks.
+        explicand: The explicand to explain.
+    """
+
+    def __init__(self, model, masker, explicand):
+        super().__init__(model, explicand)
+        # masker takes a m x n mask and returns a N x m x n matrix
+        self.masker = masker
+        self.n = explicand.shape[-1]
+
+    def value(self, S):
+        # S is a m by n binary matrix
+        inputs = self.masker(S, self.explicand)
+        m, N, *n = inputs.shape
+        print(m, N, n)
+        inputs = inputs.reshape(-1, *n)
+        values = self.model.predict(inputs).reshape(m, N, -1)
+        return np.mean(values, axis=1)
+
+    def edge_cases(self):
+        S0 = np.zeros((1, self.n))
+        S1 = np.ones((1, self.n))
+        v0 = self.value(S0)[0]
+        v1 = self.value(S1)[0]
+        return v0, v1
+
 
 class LeverageSHAP:
     def __init__(self, n, game, paired_sampling=True):
         self.game = game
         self.n = n
         self.paired_sampling = paired_sampling
-    
+
     def shap_values(self, num_samples):
         # Sample
         #self.sample()
         # A = Z P
         # y = v(z) - v0
-        # b = y - Z1 (v1 - v0) / n    
+        # b = y - Z1 (v1 - v0) / n
         # (A^T S^T S A)^-1 A^T S^T S b + (v1 - v0) / n
         # (P^T Z^T S^T S Z P)^-1 P^T Z^T S^T S b + (v1 - v0) / n
         if num_samples < 6:
-            print('Number of samples too small, setting to 6')
+            print("Number of samples too small, setting to 6")
             num_samples = 6
 
         sampling_weights = np.ones(self.n)
@@ -52,9 +127,10 @@ class LeverageSHAP:
         sampling_probs = sampling_probs[filtered_indices]
 
         values = self.game.value(coalition_matrix)
-        
+
         v0, v1 = self.game.edge_cases()
-        values_adjusted = values - (v1 - v0) * coalition_sizes/ self.n
+        v0, v1 = v0.reshape(1, -1), v1.reshape(1, -1)
+        values_adjusted = values - (v1 - v0) * coalition_sizes[:, np.newaxis]/ self.n
         regression_weights = 1 / (binom(self.n, coalition_sizes) * coalition_sizes * (self.n - coalition_sizes))
         kernel_weights = regression_weights / sampling_probs
 
@@ -69,14 +145,22 @@ class LeverageSHAP:
 
             yellow_start="\033[33m"
             yellow_end="\033[0m"
-            print(f'{yellow_start}Warning:{yellow_end} Singular matrix in Leverage SHAP with num_samples={num_samples} and num_players={self.n}, adding ridge regularization with alpha={sqrt_alpha**2}.')
+            print(f"{yellow_start}Warning:{yellow_end} Singular matrix in Leverage SHAP with num_samples={num_samples} and num_players={self.n}, adding ridge regularization with alpha={sqrt_alpha**2}.")
 
         AtA_inv_Atb = np.linalg.lstsq(AtA, Atb, rcond=None)[0]
-        
+
         return AtA_inv_Atb + (v1 - v0) / self.n
 
-def leverage_shap(baseline, explicand, model, num_samples):
-    game = Game(model, baseline, explicand)
-    n = baseline.shape[1]
+def leverage_shap(masker, explicand, model, num_samples):
+    if isinstance(masker, Callable):
+        game = CustomMaskerGame(model, masker, explicand)
+    elif isinstance(masker, np.ndarray):
+        if masker.ndim == 1 or masker.shape[0] == 1:
+            baseline = masker
+            game = BaselineGame(model, baseline, explicand)
+        else:
+            background_data = masker
+            game = MarginalGame(model, background_data, explicand)
+    n = explicand.shape[-1]
     estimator = LeverageSHAP(n, game, paired_sampling=True)
     return estimator.shap_values(num_samples)

--- a/leverageshap/estimators/leverage_shap.py
+++ b/leverageshap/estimators/leverage_shap.py
@@ -81,7 +81,6 @@ class CustomMaskerGame(Game):
         # S is a m by n binary matrix
         inputs = self.masker(S, self.explicand)
         m, N, *n = inputs.shape
-        print(m, N, n)
         inputs = inputs.reshape(-1, *n)
         values = self.model.predict(inputs).reshape(m, N, -1)
         return np.mean(values, axis=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "leverageshap"
+version = "0.0.1"
+description = "Leverage SHAP."
+readme = "README.md"
+authors = [
+    { name = "Christopher Musco" },
+    { name = "R. Teal Witter" },
+]
+requires-python = ">=3.12"
+dependencies = [
+    "numpy==2.3.2",
+    "shap==0.49.1",
+    "xgboost==3.1.1",
+    "matplotlib==3.10.7",
+    "tabulate==0.9.0",
+    "networkx==3.5",
+    "scipy==1.16.1",
+    "scienceplots==2.1.1",
+]
+
+[build-system]
+requires = ["uv_build>=0.8.6,<0.9.0"]
+build-backend = "uv_build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.12"
 dependencies = [
     "numpy==2.3.2",
     "shap==0.49.1",
-    "xgboost==3.1.1",
+    "xgboost==2.0.3",
     "matplotlib==3.10.7",
     "tabulate==0.9.0",
     "networkx==3.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,5 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.8.6,<0.9.0"]
-build-backend = "uv_build"
+requires = ["flit_core >=3.11,<4"]
+build-backend = "flit_core.buildapi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "numpy==2.3.2",
-    "shap==0.49.1",
+    "shap==0.50.0",
     "xgboost==2.0.3",
     "matplotlib==3.10.7",
     "tabulate==0.9.0",


### PR DESCRIPTION
This PR includes several improvements and new features I coded together over the last days. I hope they are helpful for other people as well. Therefore, I'm writing this PR. I don't know if you want to have all of the changes I made in your codebase. Feel free to cherry-pick individual changes. Unfortunately, I was not forward-looking enough to implement each of the changes on a separate branch.

1. Multi-Class Classifiers, for example, for the Adult dataset, currently crash LeverageSHAP in [line 57 of `estimators/leverage_shap.py`](https://github.com/rtealwitter/leverageshap/blob/bb6cf14db74d06c3a3fffee05859221e310a0dbd/leverageshap/estimators/leverage_shap.py#L57) due to shape errors. I added some broadcasting to handle this case.

2. I added `Game` subclasses for Marginal SHAP (e.g. value average over several background data samples). This is the SHAP value computed by KernelSHAP when passing a matrix of samples as `data`/baseline instead of a single sample.

3. I added support for custom maskers as supported by the newer `shap` classes like `PermutationSHAP`. This allows using more elaborate value functions in LeverageSHAP. 

4. I added a `pyproject.toml` file for using LeverageSHAP more easily from outside code. The `pyproject.toml` file allows for installing LeverageSHAP, including all dependencies, using `pip install .` from the repository root directory. For my use case, I also pinned all dependencies to the current versions. 

I have tested all features on individual instances and compared the estimated SHAP values to results from KernelSHAP and PermutationSHAP, but I have not exhaustively tested any of the features/fixes. 

One further note: The `LICENSE` file misses a `T` in the first line, and the `<year>` placeholder is left unfilled.